### PR TITLE
change FBSDKCoreKit to 11.0.0

### DIFF
--- a/ios/flutter_facebook_sdk.podspec
+++ b/ios/flutter_facebook_sdk.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'FBSDKCoreKit', '~> 9.1.0'
+  s.dependency 'FBSDKCoreKit', '~> 11.0.0'
   s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement?
Upgrade FBSDKCoreKit to 11.0.0 to be compatible with:
flutter_facebook_auth 3.4.1

