### PR TITLE
initializeSDK and null check error

### DIFF
--- a/ios/Classes/SwiftFlutterFacebookSdkPlugin.swift
+++ b/ios/Classes/SwiftFlutterFacebookSdkPlugin.swift
@@ -174,6 +174,10 @@ public class SwiftFlutterFacebookSdkPlugin: NSObject, FlutterPlugin, FlutterStre
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
+        case "initializeSDK":
+            ApplicationDelegate.initializeSDK(nil)
+            result(nil)
+            return
         case "getPlatformVersion":
             result("iOS " + UIDevice.current.systemVersion)
         case "getDeepLinkUrl":
@@ -272,9 +276,9 @@ public class SwiftFlutterFacebookSdkPlugin: NSObject, FlutterPlugin, FlutterStre
                 return
             }
             if  let myArgs = args as? [String: Any],
-                let enabled = myArgs["enabled"] as? Bool{
+                let enabled = myArgs["enabled"] as? Bool {
                 Settings.setAdvertiserTrackingEnabled(enabled)
-                result(nil)
+                result(enabled)
                 return
             }
         case "logEvent":

--- a/lib/flutter_facebook_sdk.dart
+++ b/lib/flutter_facebook_sdk.dart
@@ -53,6 +53,12 @@ class FlutterFacebookSdk {
     return url;
   }
 
+  /// InitializeSDK for iOS
+  Future<bool> initializeSDK() async {
+    await _channel.invokeMethod("initializeSDK");
+    return true;
+  }
+
   /// Logs App Activate Event of FBSDK
   Future<bool> logActivateApp() async {
     await _channel.invokeMethod("activateApp");


### PR DESCRIPTION
The setAdvertiserTrackingEnabled was throwing a null check error

In iOS I've got this error "FBSDKLog: FBSDKGraphRequestConnection cannot be started before Facebook SDK initialized", so I need to implement this method "initializeSDK" to work